### PR TITLE
Added terraform_remote_state module

### DIFF
--- a/terraform_example.yml
+++ b/terraform_example.yml
@@ -4,6 +4,14 @@
    hosts: all
    gather_facts: no
    tasks:
+    - terraform_remote_state:
+        dir: "/path/to/terraform/stack"
+        backend: s3
+        backend_config:
+          bucket: "my-s3-bucket"
+          key: "path/to/terraform.tfstate"
+          region: ap-southeast-2
+
     - terraform:
         dir: "/path/to/terraform/stack"
         action: "apply"


### PR DESCRIPTION
- Added terraform_remote_state module. This runs 'terraform remote config' to configure a remote state backend.
- Changed teraform module to accept standard parameters for access credentials, including assumed roles.
- Changed teraform module to attempt to load remote state local copy if a statefile is not found.
